### PR TITLE
Fixes handling of Haskell exceptions with a custom exception handler

### DIFF
--- a/System/Fuse.hsc
+++ b/System/Fuse.hsc
@@ -501,7 +501,7 @@ withStructFuse pFuseChan pArgs ops handler f =
         else E.finally (f structFuse)
                        (fuse_destroy structFuse)
     where fuseHandler :: e -> IO CInt
-          fuseHandler e = handler e >>= return . unErrno
+          fuseHandler e = handler e >>= return . negate . unErrno
           wrapGetAttr :: CGetAttr
           wrapGetAttr pFilePath pStat = handle fuseHandler $
               do filePath <- peekCString pFilePath


### PR DESCRIPTION
The Errno values returned by the exception handler were returned
without negating them. This led to client programs always reporting
'Numerical result out of range' instead of the actual errno value.
