### PR TITLE
Fix build under FreeBSD

### DIFF
--- a/HFuse.cabal
+++ b/HFuse.cabal
@@ -32,6 +32,7 @@ Library
       if os(freebsd)
          Includes:           sys/param.h, sys/mount.h
          CC-Options:           "-Df_namelen=f_namemax"
+         CC-Options:           "-DFUSE_USE_VERSION=26"
       else
          Includes:               sys/statfs.h
 


### PR DESCRIPTION
Current builds fail with FUSE stating that `On FreeBSD API version 25 or greater must be used`. Likewise macOS builds (and as stated by the error message), using an API version greater than 25 seems to allow hfuse to build and work as usual.
Being an almost complete stranger to FUSE, I have no knowledge about the side-effects or implications of such; however haven't put much thought to it considering macOS builds appears to suffer from the same "issue" (also mitigated in the same way)